### PR TITLE
Add Diebold-Mariano comparison for forecast models

### DIFF
--- a/my_forecast_app_v1/models/stat_tests.py
+++ b/my_forecast_app_v1/models/stat_tests.py
@@ -1,0 +1,71 @@
+"""Pruebas estadísticas para comparar modelos de pronóstico."""
+
+import numpy as np
+from scipy.stats import t
+
+
+def diebolt_mariano(actual, pred1, pred2, h=1, loss="MSE", alternative="two-sided"):
+    """Calcula el estadístico y el p-valor de la prueba Diebold-Mariano.
+
+    Parameters
+    ----------
+    actual : array-like
+        Observaciones reales.
+    pred1 : array-like
+        Predicciones del modelo 1.
+    pred2 : array-like
+        Predicciones del modelo 2.
+    h : int, opcional
+        Horizonte de pronóstico utilizado por los modelos (1 por defecto).
+    loss : {"MSE", "MAE"}, opcional
+        Función de pérdida para calcular las diferencias de error.
+    alternative : {"two-sided", "less", "greater"}, opcional
+        Tipo de hipótesis alternativa para el cálculo del p-valor.
+
+    Returns
+    -------
+    tuple
+        ``(dm_statistic, p_value)`` donde ``dm_statistic`` es el valor del
+        estadístico DM y ``p_value`` el p-valor asociado.
+    """
+    actual = np.asarray(actual)
+    pred1 = np.asarray(pred1)
+    pred2 = np.asarray(pred2)
+
+    e1 = actual - pred1
+    e2 = actual - pred2
+
+    loss = loss.upper()
+    if loss == "MSE":
+        d = e1 ** 2 - e2 ** 2
+    elif loss in {"MAE", "MAD"}:
+        d = np.abs(e1) - np.abs(e2)
+    else:
+        raise ValueError("Loss no soportada: use 'MSE' o 'MAE'.")
+
+    d_mean = np.mean(d)
+    n = len(d)
+
+    def autocov(x, lag):
+        return np.sum((x[lag:] - d_mean) * (x[: n - lag] - d_mean)) / n
+
+    gamma0 = autocov(d, 0)
+    var_d = gamma0
+    for lag in range(1, h):
+        gamma = autocov(d, lag)
+        weight = 1 - lag / h
+        var_d += 2 * weight * gamma
+
+    dm_stat = d_mean / np.sqrt(var_d / n)
+
+    df = n - 1
+    if alternative == "two-sided":
+        p_value = 2 * (1 - t.cdf(np.abs(dm_stat), df))
+    elif alternative == "less":
+        p_value = t.cdf(dm_stat, df)
+    elif alternative == "greater":
+        p_value = 1 - t.cdf(dm_stat, df)
+    else:
+        raise ValueError("Valor de 'alternative' no válido.")
+
+    return dm_stat, p_value

--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -63,6 +63,32 @@
             </ul>
         {% endif %}
 
+        {% if dm_results %}
+            <h2 class="mt-4">Diebold-Mariano</h2>
+            <div class="table-responsive">
+                <table class="table table-striped table-hover table-sm text-center">
+                    <thead>
+                        <tr>
+                            <th>Modelos</th>
+                            <th>Estadístico</th>
+                            <th>p-valor</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for pair, res in dm_results.items() %}
+                        {% set significant = res.p_value < 0.05 %}
+                        <tr{% if significant %} class="table-warning"{% endif %}>
+                            <td>{{ pair }}</td>
+                            <td>{{ '%.4f'|format(res.statistic) }}</td>
+                            <td>{{ '%.4f'|format(res.p_value) }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+                <p><small>Se resalta la fila cuando el p-valor es menor a 0.05.</small></p>
+            </div>
+        {% endif %}
+
         {% if metrics_table %}
         <!-- Formulario para seleccionar el modelo a graficar y enviar datos -->
         <form method="POST" action="{{ url_for('plot') }}" target="_blank" class="mt-4">


### PR DESCRIPTION
## Summary
- implement Diebold-Mariano test with HAC variance in `models/stat_tests.py`
- compute pairwise DM statistics for all models and expose results in the web UI
- show table highlighting significant differences between model forecasts

## Testing
- `python -m py_compile app.py models/stat_tests.py`
- `python - <<'PY'
import numpy as np
from models.stat_tests import diebolt_mariano
actual = np.array([1,2,3,4,5])
pred1 = np.array([1,2,2.9,3.9,5.1])
pred2 = np.array([0.9,2.1,3.2,4.2,5.0])
stat, p = diebolt_mariano(actual, pred1, pred2)
print('stat', stat, 'p', p)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bf2b591f9c832fbc59f1266cfcccff