### PR TITLE
Add residuals and confidence intervals to models and views

### DIFF
--- a/my_forecast_app_v1/models/ml_models.py
+++ b/my_forecast_app_v1/models/ml_models.py
@@ -5,6 +5,7 @@ import pandas as pd
 import math
 from sklearn.linear_model import LinearRegression
 from sklearn.ensemble import RandomForestRegressor
+import statsmodels.api as sm
 
 
 def create_supervised_data(series, lag=1):
@@ -18,23 +19,34 @@ def create_supervised_data(series, lag=1):
 
 
 def train_linear_regression(train_data, test_data, forecast_steps=1):
-    """Entrena una regresión lineal y pronostica."""
+    """Entrena una regresión lineal y pronostica con intervalos."""
     X, y = create_supervised_data(train_data, lag=1)
     model = LinearRegression()
     model.fit(X, y)
 
+    # Ajuste con statsmodels para obtener intervalos
+    X_sm = sm.add_constant(X)
+    sm_model = sm.OLS(y, X_sm).fit()
+
     test_predictions = []
+    conf_int = []
     current_input = train_data[-1]
 
     # Predicción recursiva: usamos el último valor conocido como entrada
     for actual_value in test_data:
         X_test = np.array([current_input]).reshape(1, -1)
         y_pred = model.predict(X_test)[0]
+        X_test_sm = sm.add_constant(X_test, has_constant="add")
+        pred_res = sm_model.get_prediction(X_test_sm)
+        ci = pred_res.conf_int(alpha=0.05)[0]
+        conf_int.append(ci.tolist())
         test_predictions.append(y_pred)
         # Para la siguiente iteración usamos el valor real observado
         current_input = actual_value
 
     test_predictions = np.array(test_predictions)
+    conf_int = np.array(conf_int)
+    residuals = test_data - test_predictions
 
     # Cálculo de métricas
     mae = np.mean(np.abs(test_predictions - test_data))
@@ -68,25 +80,37 @@ def train_linear_regression(train_data, test_data, forecast_steps=1):
         "R^2": round(r2, 4),
     }
 
-    return metrics, test_predictions, [float(x) for x in forecast_next]
+    return (
+        metrics,
+        test_predictions,
+        [float(x) for x in forecast_next],
+        residuals.tolist(),
+        conf_int.tolist(),
+    )
 
 
 def train_random_forest(train_data, test_data, forecast_steps=1):
-    """Entrena un bosque aleatorio para pronosticar."""
+    """Entrena un bosque aleatorio para pronosticar con intervalos aproximados."""
     X, y = create_supervised_data(train_data, lag=1)
     model = RandomForestRegressor(n_estimators=100)
     model.fit(X, y)
 
     test_predictions = []
+    conf_int = []
     current_input = train_data[-1]
 
     for actual_value in test_data:
         X_test = np.array([current_input]).reshape(1, -1)
-        y_pred = model.predict(X_test)[0]
+        tree_preds = np.array([est.predict(X_test)[0] for est in model.estimators_])
+        y_pred = tree_preds.mean()
+        ci = np.percentile(tree_preds, [2.5, 97.5])
+        conf_int.append(ci.tolist())
         test_predictions.append(y_pred)
         current_input = actual_value
 
     test_predictions = np.array(test_predictions)
+    conf_int = np.array(conf_int)
+    residuals = test_data - test_predictions
 
     mae = np.mean(np.abs(test_predictions - test_data))
     rmse = math.sqrt(np.mean((test_predictions - test_data) ** 2))
@@ -118,4 +142,10 @@ def train_random_forest(train_data, test_data, forecast_steps=1):
         "R^2": round(r2, 4),
     }
 
-    return metrics, test_predictions, [float(x) for x in forecast_next]
+    return (
+        metrics,
+        test_predictions,
+        [float(x) for x in forecast_next],
+        residuals.tolist(),
+        conf_int.tolist(),
+    )

--- a/my_forecast_app_v1/models/ts_models.py
+++ b/my_forecast_app_v1/models/ts_models.py
@@ -8,7 +8,7 @@ from statsmodels.tsa.holtwinters import ExponentialSmoothing
 
 
 def train_sarima(train_data, test_data, forecast_steps=1):
-    """Entrena un modelo SARIMA y devuelve métricas y pronósticos."""
+    """Entrena un modelo SARIMA y devuelve métricas, residuales e intervalos."""
     # Por simplicidad, usaremos un (1,1,1) y estacionalidad = 12
     # En la práctica, se deben seleccionar p,d,q y parámetros estacionales mediante búsqueda.
     if len(train_data) == 0 or len(test_data) == 0:
@@ -19,7 +19,7 @@ def train_sarima(train_data, test_data, forecast_steps=1):
             "MAPE": float("nan"),
             "R^2": float("nan"),
         }
-        return metrics, np.array([]), [None] * forecast_steps
+        return metrics, np.array([]), [None] * forecast_steps, np.array([]), []
     model = SARIMAX(
         train_data,
         order=(1, 1, 1),
@@ -29,10 +29,16 @@ def train_sarima(train_data, test_data, forecast_steps=1):
     )
     sarima_fit = model.fit(disp=False)
 
-    # Predicción en el set de prueba
-    predictions = sarima_fit.predict(
+    # Predicción en el set de prueba con intervalos
+    pred_res = sarima_fit.get_prediction(
         start=len(train_data), end=len(train_data) + len(test_data) - 1, dynamic=False
     )
+    predictions = pred_res.predicted_mean
+    # ``conf_int`` puede devolverse como DataFrame o arreglo; lo convertimos
+    # a ``np.ndarray`` de forma robusta para evitar errores al acceder a
+    # ``.values`` en estructuras que ya son ``ndarray``.
+    conf_int = np.asarray(pred_res.conf_int())
+    residuals = test_data - predictions
 
     # Métricas de error
     mae = np.mean(np.abs(predictions - test_data))
@@ -63,11 +69,17 @@ def train_sarima(train_data, test_data, forecast_steps=1):
         "R^2": round(r2, 4),
     }
 
-    return metrics, predictions, forecast_next.tolist()
+    return (
+        metrics,
+        predictions,
+        forecast_next.tolist(),
+        residuals.tolist(),
+        conf_int.tolist(),
+    )
 
 
 def train_holtwinters(train_data, test_data, forecast_steps=1):
-    """Entrena un modelo Holt-Winters y devuelve métricas y pronósticos."""
+    """Entrena un modelo Holt-Winters y devuelve métricas y residuales."""
     if len(train_data) == 0 or len(test_data) == 0:
         metrics = {
             "Modelo": "Holt-Winters",
@@ -76,7 +88,7 @@ def train_holtwinters(train_data, test_data, forecast_steps=1):
             "MAPE": float("nan"),
             "R^2": float("nan"),
         }
-        return metrics, np.array([]), [None] * forecast_steps
+        return metrics, np.array([]), [None] * forecast_steps, np.array([]), []
     # Ver cuántos datos hay en train
     n_train = len(train_data)
     # Solo usar estacionalidad si hay >= 2 ciclos de 12
@@ -92,9 +104,15 @@ def train_holtwinters(train_data, test_data, forecast_steps=1):
     hw_fit = model.fit()
 
     # Predicción sobre el conjunto de prueba
-    predictions = hw_fit.predict(
+    pred_res = hw_fit.get_prediction(
         start=len(train_data), end=len(train_data) + len(test_data) - 1
     )
+    predictions = pred_res.predicted_mean
+    try:
+        conf_int = np.asarray(pred_res.conf_int())
+    except Exception:
+        conf_int = np.array([[np.nan, np.nan]] * len(predictions))
+    residuals = test_data - predictions
 
     mae = np.mean(np.abs(predictions - test_data))
     rmse = math.sqrt(np.mean((predictions - test_data) ** 2))
@@ -123,4 +141,10 @@ def train_holtwinters(train_data, test_data, forecast_steps=1):
         "R^2": round(r2, 4),
     }
 
-    return metrics, predictions, forecast_next.tolist()
+    return (
+        metrics,
+        predictions,
+        forecast_next.tolist(),
+        residuals.tolist(),
+        conf_int.tolist(),
+    )

--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -107,6 +107,12 @@
             {% for model, preds in predictions_dict.items() %}
             <input type="hidden" name="pred_{{ model }}" value='{{ preds|tojson }}'>
             {% endfor %}
+            {% for model, resid in residuals_dict.items() %}
+            <input type="hidden" name="resid_{{ model }}" value='{{ resid|tojson }}'>
+            {% endfor %}
+            {% for model, ci in conf_int_dict.items() %}
+            <input type="hidden" name="confint_{{ model }}" value='{{ ci|tojson }}'>
+            {% endfor %}
 
             <button type="submit" class="btn btn-success mt-2">Ejecutar</button>
         </form>

--- a/my_forecast_app_v1/templates/plot.html
+++ b/my_forecast_app_v1/templates/plot.html
@@ -16,6 +16,7 @@
         <p><strong>Entrenamiento:</strong> {{ train_display }}</p>
         <p><strong>Reales (test):</strong> {{ test_display }}</p>
         <p><strong>Pronosticados:</strong> {{ pred_display }}</p>
+        <p><strong>Residuales:</strong> {{ resid_display }}</p>
         <!-- Canvas donde se dibujará el gráfico con Chart.js -->
         <canvas id="chart" height="100"></canvas>
         <!-- Formulario para descargar los datos en Excel -->
@@ -24,6 +25,9 @@
             <input type="hidden" name="train_series" value='{{ train_series|tojson }}' />
             <input type="hidden" name="test_series" value='{{ test_series|tojson }}' />
             <input type="hidden" name="pred_series" value='{{ pred_series|tojson }}' />
+            <input type="hidden" name="resid_series" value='{{ resid_series|tojson }}' />
+            <input type="hidden" name="ci_lower" value='{{ ci_lower|tojson }}' />
+            <input type="hidden" name="ci_upper" value='{{ ci_upper|tojson }}' />
             <input type="hidden" name="dates" value='{{ dates|tojson }}' />
             <button type="submit" class="btn btn-primary">Guardar en Excel</button>
         </form>
@@ -36,8 +40,11 @@
         const train = {{ train_series|tojson }};
         const testReal = {{ test_series|tojson }};
         const testPred = {{ pred_series|tojson }};
+        const resid = {{ resid_series|tojson }};
+        const ciLow = {{ ci_lower|tojson }};
+        const ciHigh = {{ ci_upper|tojson }};
 
-        // Configura y renderiza el gráfico de líneas con las tres series
+        // Configura y renderiza el gráfico de líneas con las series y bandas de confianza
         new Chart(document.getElementById('chart'), {
             type: 'line',
             data: {
@@ -45,8 +52,17 @@
                 datasets: [
                     {label: 'Entrenamiento', data: train, borderColor: 'blue', fill:false},
                     {label: 'Real (test)', data: testReal, borderColor: 'green', fill:false},
-                    {label: 'Pronóstico', data: testPred, borderColor: 'red', fill:false}
+                    {label: 'Pronóstico', data: testPred, borderColor: 'red', fill:false},
+                    {label: 'Residual', data: resid, borderColor: 'purple', fill:false, yAxisID: 'y1'},
+                    {label: 'CI inferior', data: ciLow, borderColor: 'rgba(255,0,0,0.3)', fill:false},
+                    {label: 'CI superior', data: ciHigh, borderColor: 'rgba(255,0,0,0.3)', fill:false}
                 ]
+            },
+            options: {
+                scales: {
+                    y: {position: 'left'},
+                    y1: {position: 'right', grid: {drawOnChartArea: false}}
+                }
             }
         });
     </script>


### PR DESCRIPTION
## Summary
- compute residuals and confidence intervals for SARIMA and Holt-Winters models
- generate residuals and interval estimates for linear regression and random forest
- surface residuals and confidence bands in app views, plots and Excel exports
- convert SARIMA and Holt-Winters confidence intervals to numpy arrays to avoid attribute errors

## Testing
- `python -m py_compile my_forecast_app_v1/models/ts_models.py my_forecast_app_v1/models/ml_models.py my_forecast_app_v1/app.py`
- `python - <<'PY'
import numpy as np
from my_forecast_app_v1.models.ts_models import train_sarima
train = np.arange(1,50)
test = np.arange(50,60)
metrics, pred, fc, res, ci = train_sarima(train, test, 1)
print('pred len', len(pred), 'ci shape', np.array(ci).shape)
print('first ci row', ci[0])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bfc32cf29c832f80e01f3f7397d0fe