### PR TITLE
Add 95% confidence intervals to forecasts

### DIFF
--- a/my_forecast_app_v1/models/utils.py
+++ b/my_forecast_app_v1/models/utils.py
@@ -1,0 +1,78 @@
+"""Utilities shared across forecasting models."""
+
+from typing import Iterable, List, Tuple
+
+import numpy as np
+from scipy.stats import t
+
+
+def residual_confidence_intervals(
+    actual: Iterable[float],
+    predictions: Iterable[float],
+    forecast_values: Iterable[float],
+    alpha: float = 0.05,
+) -> Tuple[List[float], List[float]]:
+    """Compute residual-based confidence intervals for forecasts.
+
+    Parameters
+    ----------
+    actual : Iterable[float]
+        Observed values from the test set.
+    predictions : Iterable[float]
+        Model predictions aligned with ``actual``.
+    forecast_values : Iterable[float]
+        Future forecast values produced by the model.
+    alpha : float, optional
+        Significance level (0.05 by default for a 95% interval).
+
+    Returns
+    -------
+    tuple of list
+        Two lists (lower bounds, upper bounds) of the same length as
+        ``forecast_values`` containing the confidence interval limits.
+    """
+    forecast_list = list(forecast_values)
+    n_forecast = len(forecast_list)
+    if n_forecast == 0:
+        return [], []
+
+    actual_arr = np.asarray(list(actual), dtype=float)
+    pred_arr = np.asarray(list(predictions), dtype=float)
+
+    if actual_arr.size == 0 or pred_arr.size == 0:
+        return [None] * n_forecast, [None] * n_forecast
+
+    residuals = actual_arr - pred_arr
+    residuals = residuals[~np.isnan(residuals)]
+
+    if residuals.size == 0:
+        return [None] * n_forecast, [None] * n_forecast
+
+    if residuals.size > 1:
+        resid_std = np.std(residuals, ddof=1)
+        degrees_freedom = residuals.size - 1
+        critical_value = t.ppf(1 - alpha / 2, degrees_freedom)
+    else:
+        resid_std = np.std(residuals)
+        critical_value = 1.96  # Approximation when only one residual is available
+
+    if np.isnan(resid_std):
+        return [None] * n_forecast, [None] * n_forecast
+
+    if resid_std == 0:
+        margins = [0.0] * n_forecast
+    else:
+        margin = float(critical_value * resid_std)
+        margins = [margin] * n_forecast
+
+    lower_bounds: List[float] = []
+    upper_bounds: List[float] = []
+    for value, margin in zip(forecast_list, margins):
+        if value is None or margin is None or np.isnan(value):
+            lower_bounds.append(None)
+            upper_bounds.append(None)
+            continue
+        lower_bounds.append(float(value) - margin)
+        upper_bounds.append(float(value) + margin)
+
+    return lower_bounds, upper_bounds

--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -55,12 +55,13 @@
         {% if forecast_values %}
             <!-- Lista con los valores pronosticados por cada modelo -->
             <h2 class="mt-4">Pronóstico de los próximos puntos</h2>
-            <!-- forecast_values already holds comma-separated strings rounded to two decimals -->
+            <!-- forecast_values ya incluye valores formateados con sus intervalos -->
             <ul>
             {% for model, fc_val in forecast_values.items() %}
                 <li><strong>{{ model }}:</strong> {{ fc_val }}</li>
             {% endfor %}
             </ul>
+            <p><small>Se muestran intervalos de confianza al 95% para cada pronóstico.</small></p>
         {% endif %}
 
         {% if dm_results %}


### PR DESCRIPTION
## Summary
- add a reusable helper to compute residual-based confidence intervals
- return confidence interval bounds from every forecasting model and expose them through the Flask view
- display 95% confidence intervals for each forecast in the main page

## Testing
- python -m compileall my_forecast_app_v1

------
https://chatgpt.com/codex/tasks/task_e_68d423fcab28832f87ce01cd63802d61