### PR TITLE
Show confidence intervals only on plots

### DIFF
--- a/my_forecast_app_v1/models/utils.py
+++ b/my_forecast_app_v1/models/utils.py
@@ -1,0 +1,78 @@
+"""Utilities shared across forecasting models."""
+
+from typing import Iterable, List, Tuple
+
+import numpy as np
+from scipy.stats import t
+
+
+def residual_confidence_intervals(
+    actual: Iterable[float],
+    predictions: Iterable[float],
+    forecast_values: Iterable[float],
+    alpha: float = 0.05,
+) -> Tuple[List[float], List[float]]:
+    """Compute residual-based confidence intervals for forecasts.
+
+    Parameters
+    ----------
+    actual : Iterable[float]
+        Observed values from the test set.
+    predictions : Iterable[float]
+        Model predictions aligned with ``actual``.
+    forecast_values : Iterable[float]
+        Future forecast values produced by the model.
+    alpha : float, optional
+        Significance level (0.05 by default for a 95% interval).
+
+    Returns
+    -------
+    tuple of list
+        Two lists (lower bounds, upper bounds) of the same length as
+        ``forecast_values`` containing the confidence interval limits.
+    """
+    forecast_list = list(forecast_values)
+    n_forecast = len(forecast_list)
+    if n_forecast == 0:
+        return [], []
+
+    actual_arr = np.asarray(list(actual), dtype=float)
+    pred_arr = np.asarray(list(predictions), dtype=float)
+
+    if actual_arr.size == 0 or pred_arr.size == 0:
+        return [None] * n_forecast, [None] * n_forecast
+
+    residuals = actual_arr - pred_arr
+    residuals = residuals[~np.isnan(residuals)]
+
+    if residuals.size == 0:
+        return [None] * n_forecast, [None] * n_forecast
+
+    if residuals.size > 1:
+        resid_std = np.std(residuals, ddof=1)
+        degrees_freedom = residuals.size - 1
+        critical_value = t.ppf(1 - alpha / 2, degrees_freedom)
+    else:
+        resid_std = np.std(residuals)
+        critical_value = 1.96  # Approximation when only one residual is available
+
+    if np.isnan(resid_std):
+        return [None] * n_forecast, [None] * n_forecast
+
+    if resid_std == 0:
+        margins = [0.0] * n_forecast
+    else:
+        margin = float(critical_value * resid_std)
+        margins = [margin] * n_forecast
+
+    lower_bounds: List[float] = []
+    upper_bounds: List[float] = []
+    for value, margin in zip(forecast_list, margins):
+        if value is None or margin is None or np.isnan(value):
+            lower_bounds.append(None)
+            upper_bounds.append(None)
+            continue
+        lower_bounds.append(float(value) - margin)
+        upper_bounds.append(float(value) + margin)
+
+    return lower_bounds, upper_bounds

--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -55,12 +55,12 @@
         {% if forecast_values %}
             <!-- Lista con los valores pronosticados por cada modelo -->
             <h2 class="mt-4">Pronóstico de los próximos puntos</h2>
-            <!-- forecast_values already holds comma-separated strings rounded to two decimals -->
             <ul>
             {% for model, fc_val in forecast_values.items() %}
                 <li><strong>{{ model }}:</strong> {{ fc_val }}</li>
             {% endfor %}
             </ul>
+            <p><small>Los intervalos de confianza se visualizan en la gráfica del modelo seleccionado.</small></p>
         {% endif %}
 
         {% if dm_results %}
@@ -104,8 +104,15 @@
             <input type="hidden" name="train_series" value='{{ train_series|tojson }}'>
             <input type="hidden" name="test_series" value='{{ test_series|tojson }}'>
             <input type="hidden" name="dates" value='{{ dates|tojson }}'>
+            <input type="hidden" name="future_dates" value='{{ (future_dates or [])|tojson }}'>
+            {% set forecast_series_dict = forecast_series or {} %}
+            {% set forecast_intervals_dict = forecast_intervals or {} %}
             {% for model, preds in predictions_dict.items() %}
             <input type="hidden" name="pred_{{ model }}" value='{{ preds|tojson }}'>
+            <input type="hidden" name="forecast_{{ model }}" value='{{ (forecast_series_dict.get(model) or [])|tojson }}'>
+            {% set ci_dict = forecast_intervals_dict.get(model) or {} %}
+            <input type="hidden" name="ci_lower_{{ model }}" value='{{ (ci_dict.get("lower") or [])|tojson }}'>
+            <input type="hidden" name="ci_upper_{{ model }}" value='{{ (ci_dict.get("upper") or [])|tojson }}'>
             {% endfor %}
 
             <button type="submit" class="btn btn-success mt-2">Ejecutar</button>

--- a/my_forecast_app_v1/templates/plot.html
+++ b/my_forecast_app_v1/templates/plot.html
@@ -16,6 +16,9 @@
         <p><strong>Entrenamiento:</strong> {{ train_display }}</p>
         <p><strong>Reales (test):</strong> {{ test_display }}</p>
         <p><strong>Pronosticados:</strong> {{ pred_display }}</p>
+        {% if forecast_series %}
+        <p><strong>Pronóstico futuro:</strong> {{ forecast_display }}</p>
+        {% endif %}
         <!-- Canvas donde se dibujará el gráfico con Chart.js -->
         <canvas id="chart" height="100"></canvas>
         <!-- Formulario para descargar los datos en Excel -->
@@ -32,20 +35,85 @@
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
-        const labels = {{ dates|tojson }};
+        const historicalLabels = {{ dates|tojson }};
+        const futureLabels = {{ future_dates|tojson }};
+        const labels = historicalLabels.concat(futureLabels);
+
         const train = {{ train_series|tojson }};
         const testReal = {{ test_series|tojson }};
         const testPred = {{ pred_series|tojson }};
+        const forecastFuture = {{ forecast_series|tojson }};
+        const forecastLower = {{ forecast_lower|tojson }};
+        const forecastUpper = {{ forecast_upper|tojson }};
 
-        // Configura y renderiza el gráfico de líneas con las tres series
+        const forecastPadding = Array(historicalLabels.length).fill(null);
+        const extension = Array(futureLabels.length).fill(null);
+
+        const trainPlot = train.concat(extension);
+        const testPlot = testReal.concat(extension);
+        const predPlot = testPred.concat(extension);
+        const forecastPlot = forecastPadding.concat(forecastFuture);
+        const lowerPlot = forecastPadding.concat(forecastLower);
+        const upperPlot = forecastPadding.concat(forecastUpper);
+
+        // Configura y renderiza el gráfico de líneas con todas las series
         new Chart(document.getElementById('chart'), {
             type: 'line',
             data: {
                 labels: labels,
                 datasets: [
-                    {label: 'Entrenamiento', data: train, borderColor: 'blue', fill:false},
-                    {label: 'Real (test)', data: testReal, borderColor: 'green', fill:false},
-                    {label: 'Pronóstico', data: testPred, borderColor: 'red', fill:false}
+                    {
+                        label: 'Entrenamiento',
+                        data: trainPlot,
+                        borderColor: 'blue',
+                        fill: false,
+                        spanGaps: true
+                    },
+                    {
+                        label: 'Real (test)',
+                        data: testPlot,
+                        borderColor: 'green',
+                        fill: false,
+                        spanGaps: true
+                    },
+                    {
+                        label: 'Pronóstico (test)',
+                        data: predPlot,
+                        borderColor: 'red',
+                        fill: false,
+                        spanGaps: true
+                    },
+                    {
+                        label: 'Pronóstico futuro',
+                        data: forecastPlot,
+                        borderColor: 'rgba(255, 99, 132, 1)',
+                        borderDash: [6, 6],
+                        fill: false,
+                        spanGaps: true
+                    },
+                    {
+                        label: 'IC 95% inferior',
+                        data: lowerPlot,
+                        borderColor: 'rgba(255, 99, 132, 0.4)',
+                        borderWidth: 1,
+                        pointRadius: 0,
+                        fill: false,
+                        spanGaps: true
+                    },
+                    {
+                        label: 'IC 95% superior',
+                        data: upperPlot,
+                        borderColor: 'rgba(255, 99, 132, 0.4)',
+                        backgroundColor: 'rgba(255, 99, 132, 0.12)',
+                        borderWidth: 1,
+                        pointRadius: 0,
+                        fill: {
+                            target: '-1',
+                            above: 'rgba(255, 99, 132, 0.12)',
+                            below: 'rgba(255, 99, 132, 0.12)'
+                        },
+                        spanGaps: true
+                    }
                 ]
             }
         });


### PR DESCRIPTION
## Summary
- add a reusable helper to compute residual-based confidence intervals
- return confidence interval bounds from every forecasting model and expose them through the Flask view
- show textual forecasts without interval annotations and render the 95% confidence bands in the interactive chart for each model

## Testing
- python -m compileall my_forecast_app_v1

------
https://chatgpt.com/codex/tasks/task_e_68d423fcab28832f87ce01cd63802d61