### PR TITLE
Remove confidence interval text from forecast display

### DIFF
--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -101,34 +101,12 @@ def index():
         )
 
         def format_forecast(vals, intervals):
-            """Return a descriptive string with forecast values and confidence intervals."""
+            """Return a descriptive string with forecast values without confidence intervals."""
             formatted_parts = []
-            lower = []
-            upper = []
-            if intervals:
-                lower = intervals.get("lower", [])
-                upper = intervals.get("upper", [])
-            for idx, val in enumerate(vals):
+            for val in vals:
                 if val is None or pd.isna(val):
                     continue
-                base = f"{float(val):.2f}"
-                low_val = None
-                up_val = None
-                if idx < len(lower):
-                    low_val = lower[idx]
-                if idx < len(upper):
-                    up_val = upper[idx]
-                if (
-                    low_val is not None
-                    and up_val is not None
-                    and not pd.isna(low_val)
-                    and not pd.isna(up_val)
-                ):
-                    formatted_parts.append(
-                        f"{base} (IC95%: {float(low_val):.2f} - {float(up_val):.2f})"
-                    )
-                else:
-                    formatted_parts.append(base)
+                formatted_parts.append(f"{float(val):.2f}")
             return "; ".join(formatted_parts) if formatted_parts else "Sin datos disponibles"
 
         formatted_forecasts = {

--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -55,13 +55,12 @@
         {% if forecast_values %}
             <!-- Lista con los valores pronosticados por cada modelo -->
             <h2 class="mt-4">Pronóstico de los próximos puntos</h2>
-            <!-- forecast_values ya incluye valores formateados con sus intervalos -->
+            <!-- forecast_values ya incluye valores formateados -->
             <ul>
             {% for model, fc_val in forecast_values.items() %}
                 <li><strong>{{ model }}:</strong> {{ fc_val }}</li>
             {% endfor %}
             </ul>
-            <p><small>Se muestran intervalos de confianza al 95% para cada pronóstico.</small></p>
         {% endif %}
 
         {% if dm_results %}


### PR DESCRIPTION
## Summary
- stop formatting forecast values with confidence interval text so they only display the predicted values
- update the forecast section in the main template to remove the confidence interval note

## Testing
- python -m compileall my_forecast_app_v1

------
https://chatgpt.com/codex/tasks/task_e_68d42a3c5e80832f851330f4acd9982e