### PR TITLE
Alinea intervalos de confianza con pronóstico mostrado

### DIFF
--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -203,7 +203,10 @@ def train_and_evaluate_all_models(df, forecast_steps=1, test_size=5):
         forecast_values : dict
             Pronósticos futuros por modelo.
         forecast_intervals : dict
-            Intervalos de confianza (al 95%) asociados a cada pronóstico.
+            Intervalos de confianza (al 95%) asociados a cada modelo,
+            separados en claves ``"test"`` y ``"forecast"`` para las
+            predicciones sobre el conjunto de prueba y los pronósticos
+            hacia adelante, respectivamente.
         train_series : list
             Serie extendida con valores de entrenamiento.
         test_series : list
@@ -341,8 +344,13 @@ def plot():
     forecast_intervals = json.loads(raw_intervals) if raw_intervals else {}
     ci_bounds = forecast_intervals.get(model_name, {}) if forecast_intervals else {}
 
-    ci_lower = ci_bounds.get("lower") if isinstance(ci_bounds, dict) else None
-    ci_upper = ci_bounds.get("upper") if isinstance(ci_bounds, dict) else None
+    if isinstance(ci_bounds, dict) and "test" in ci_bounds:
+        ci_for_plot = ci_bounds.get("test", {}) or {}
+    else:
+        ci_for_plot = ci_bounds if isinstance(ci_bounds, dict) else {}
+
+    ci_lower = ci_for_plot.get("lower") if isinstance(ci_for_plot, dict) else None
+    ci_upper = ci_for_plot.get("upper") if isinstance(ci_for_plot, dict) else None
 
     test_length = sum(1 for value in test_series if value is not None)
     total_length = len(test_series)

--- a/my_forecast_app_v1/models/dl_models.py
+++ b/my_forecast_app_v1/models/dl_models.py
@@ -46,7 +46,10 @@ def train_rnn(train_data, test_data, forecast_steps=1):
             "MAPE": float("nan"),
             "R^2": float("nan"),
         }
-        empty_ci = {"lower": [None] * forecast_steps, "upper": [None] * forecast_steps}
+        empty_ci = {
+            "test": {"lower": [None] * len(test_data), "upper": [None] * len(test_data)},
+            "forecast": {"lower": [None] * forecast_steps, "upper": [None] * forecast_steps},
+        }
         return metrics, np.array([]), [None] * forecast_steps, empty_ci
 
     X_train, y_train = prepare_data_dl(train_data)
@@ -73,6 +76,7 @@ def train_rnn(train_data, test_data, forecast_steps=1):
         current_input = current_input.reshape((1, 1, 1))
 
     predictions = np.array(predictions)
+    pred_list = predictions.tolist()
 
     # Cálculo de métricas de error y de ajuste
     mae = np.mean(np.abs(predictions - test_data))
@@ -98,10 +102,16 @@ def train_rnn(train_data, test_data, forecast_steps=1):
         next_input = np.array([[next_pred]]).reshape((1, 1, 1))
 
     forecast_list = [float(x) for x in forecast_next]
-    lower_bounds, upper_bounds = residual_confidence_intervals(
-        test_data, predictions, forecast_list
+    test_lower, test_upper = residual_confidence_intervals(
+        test_data, pred_list, pred_list
     )
-    ci_bounds = {"lower": lower_bounds, "upper": upper_bounds}
+    forecast_lower, forecast_upper = residual_confidence_intervals(
+        test_data, pred_list, forecast_list
+    )
+    ci_bounds = {
+        "test": {"lower": test_lower, "upper": test_upper},
+        "forecast": {"lower": forecast_lower, "upper": forecast_upper},
+    }
 
     metrics = {
         "Modelo": "RNN",
@@ -123,7 +133,10 @@ def train_lstm(train_data, test_data, forecast_steps=1):
             "MAPE": float("nan"),
             "R^2": float("nan"),
         }
-        empty_ci = {"lower": [None] * forecast_steps, "upper": [None] * forecast_steps}
+        empty_ci = {
+            "test": {"lower": [None] * len(test_data), "upper": [None] * len(test_data)},
+            "forecast": {"lower": [None] * forecast_steps, "upper": [None] * forecast_steps},
+        }
         return metrics, np.array([]), [None] * forecast_steps, empty_ci
 
     X_train, y_train = prepare_data_dl(train_data)
@@ -147,6 +160,7 @@ def train_lstm(train_data, test_data, forecast_steps=1):
         current_input = current_input.reshape((1, 1, 1))
 
     predictions = np.array(predictions)
+    pred_list = predictions.tolist()
 
     mae = np.mean(np.abs(predictions - test_data))
     rmse = math.sqrt(np.mean((predictions - test_data) ** 2))
@@ -170,10 +184,16 @@ def train_lstm(train_data, test_data, forecast_steps=1):
         next_input = np.array([[next_pred]]).reshape((1, 1, 1))
 
     forecast_list = [float(x) for x in forecast_next]
-    lower_bounds, upper_bounds = residual_confidence_intervals(
-        test_data, predictions, forecast_list
+    test_lower, test_upper = residual_confidence_intervals(
+        test_data, pred_list, pred_list
     )
-    ci_bounds = {"lower": lower_bounds, "upper": upper_bounds}
+    forecast_lower, forecast_upper = residual_confidence_intervals(
+        test_data, pred_list, forecast_list
+    )
+    ci_bounds = {
+        "test": {"lower": test_lower, "upper": test_upper},
+        "forecast": {"lower": forecast_lower, "upper": forecast_upper},
+    }
 
     metrics = {
         "Modelo": "LSTM",

--- a/my_forecast_app_v1/models/ml_models.py
+++ b/my_forecast_app_v1/models/ml_models.py
@@ -29,7 +29,10 @@ def train_linear_regression(train_data, test_data, forecast_steps=1):
             "MAPE": float("nan"),
             "R^2": float("nan"),
         }
-        empty_ci = {"lower": [None] * forecast_steps, "upper": [None] * forecast_steps}
+        empty_ci = {
+            "test": {"lower": [None] * len(test_data), "upper": [None] * len(test_data)},
+            "forecast": {"lower": [None] * forecast_steps, "upper": [None] * forecast_steps},
+        }
         return metrics, np.array([]), [None] * forecast_steps, empty_ci
 
     X, y = create_supervised_data(train_data, lag=1)
@@ -48,6 +51,7 @@ def train_linear_regression(train_data, test_data, forecast_steps=1):
         current_input = actual_value
 
     test_predictions = np.array(test_predictions)
+    pred_list = test_predictions.tolist()
 
     # Cálculo de métricas
     mae = np.mean(np.abs(test_predictions - test_data))
@@ -74,10 +78,16 @@ def train_linear_regression(train_data, test_data, forecast_steps=1):
         current_input = next_pred
 
     forecast_list = [float(x) for x in forecast_next]
-    lower_bounds, upper_bounds = residual_confidence_intervals(
-        test_data, test_predictions, forecast_list
+    test_lower, test_upper = residual_confidence_intervals(
+        test_data, pred_list, pred_list
     )
-    ci_bounds = {"lower": lower_bounds, "upper": upper_bounds}
+    forecast_lower, forecast_upper = residual_confidence_intervals(
+        test_data, pred_list, forecast_list
+    )
+    ci_bounds = {
+        "test": {"lower": test_lower, "upper": test_upper},
+        "forecast": {"lower": forecast_lower, "upper": forecast_upper},
+    }
 
     metrics = {
         "Modelo": "Regresión Lineal",
@@ -100,7 +110,10 @@ def train_random_forest(train_data, test_data, forecast_steps=1):
             "MAPE": float("nan"),
             "R^2": float("nan"),
         }
-        empty_ci = {"lower": [None] * forecast_steps, "upper": [None] * forecast_steps}
+        empty_ci = {
+            "test": {"lower": [None] * len(test_data), "upper": [None] * len(test_data)},
+            "forecast": {"lower": [None] * forecast_steps, "upper": [None] * forecast_steps},
+        }
         return metrics, np.array([]), [None] * forecast_steps, empty_ci
 
     X, y = create_supervised_data(train_data, lag=1)
@@ -117,6 +130,7 @@ def train_random_forest(train_data, test_data, forecast_steps=1):
         current_input = actual_value
 
     test_predictions = np.array(test_predictions)
+    pred_list = test_predictions.tolist()
 
     mae = np.mean(np.abs(test_predictions - test_data))
     rmse = math.sqrt(np.mean((test_predictions - test_data) ** 2))
@@ -141,10 +155,16 @@ def train_random_forest(train_data, test_data, forecast_steps=1):
         current_input = next_pred
 
     forecast_list = [float(x) for x in forecast_next]
-    lower_bounds, upper_bounds = residual_confidence_intervals(
-        test_data, test_predictions, forecast_list
+    test_lower, test_upper = residual_confidence_intervals(
+        test_data, pred_list, pred_list
     )
-    ci_bounds = {"lower": lower_bounds, "upper": upper_bounds}
+    forecast_lower, forecast_upper = residual_confidence_intervals(
+        test_data, pred_list, forecast_list
+    )
+    ci_bounds = {
+        "test": {"lower": test_lower, "upper": test_upper},
+        "forecast": {"lower": forecast_lower, "upper": forecast_upper},
+    }
 
     metrics = {
         "Modelo": "Random Forest",

--- a/my_forecast_app_v1/models/ts_models.py
+++ b/my_forecast_app_v1/models/ts_models.py
@@ -21,7 +21,10 @@ def train_sarima(train_data, test_data, forecast_steps=1):
             "MAPE": float("nan"),
             "R^2": float("nan"),
         }
-        empty_ci = {"lower": [None] * forecast_steps, "upper": [None] * forecast_steps}
+        empty_ci = {
+            "test": {"lower": [None] * len(test_data), "upper": [None] * len(test_data)},
+            "forecast": {"lower": [None] * forecast_steps, "upper": [None] * forecast_steps},
+        }
         return metrics, np.array([]), [None] * forecast_steps, empty_ci
     model = SARIMAX(
         train_data,
@@ -36,6 +39,7 @@ def train_sarima(train_data, test_data, forecast_steps=1):
     predictions = sarima_fit.predict(
         start=len(train_data), end=len(train_data) + len(test_data) - 1, dynamic=False
     )
+    pred_list = [float(x) for x in np.asarray(predictions)]
 
     # Métricas de error
     mae = np.mean(np.abs(predictions - test_data))
@@ -58,10 +62,16 @@ def train_sarima(train_data, test_data, forecast_steps=1):
         end=len(train_data) + len(test_data) + forecast_steps - 1,
     )
     forecast_list = [float(x) for x in np.asarray(forecast_next)]
-    lower_bounds, upper_bounds = residual_confidence_intervals(
-        test_data, predictions, forecast_list
+    test_lower, test_upper = residual_confidence_intervals(
+        test_data, pred_list, pred_list
     )
-    ci_bounds = {"lower": lower_bounds, "upper": upper_bounds}
+    forecast_lower, forecast_upper = residual_confidence_intervals(
+        test_data, pred_list, forecast_list
+    )
+    ci_bounds = {
+        "test": {"lower": test_lower, "upper": test_upper},
+        "forecast": {"lower": forecast_lower, "upper": forecast_upper},
+    }
 
     metrics = {
         "Modelo": "SARIMA",
@@ -84,7 +94,10 @@ def train_holtwinters(train_data, test_data, forecast_steps=1):
             "MAPE": float("nan"),
             "R^2": float("nan"),
         }
-        empty_ci = {"lower": [None] * forecast_steps, "upper": [None] * forecast_steps}
+        empty_ci = {
+            "test": {"lower": [None] * len(test_data), "upper": [None] * len(test_data)},
+            "forecast": {"lower": [None] * forecast_steps, "upper": [None] * forecast_steps},
+        }
         return metrics, np.array([]), [None] * forecast_steps, empty_ci
     # Ver cuántos datos hay en train
     n_train = len(train_data)
@@ -104,6 +117,7 @@ def train_holtwinters(train_data, test_data, forecast_steps=1):
     predictions = hw_fit.predict(
         start=len(train_data), end=len(train_data) + len(test_data) - 1
     )
+    pred_list = [float(x) for x in np.asarray(predictions)]
 
     mae = np.mean(np.abs(predictions - test_data))
     rmse = math.sqrt(np.mean((predictions - test_data) ** 2))
@@ -124,10 +138,16 @@ def train_holtwinters(train_data, test_data, forecast_steps=1):
         end=len(train_data) + len(test_data) + forecast_steps - 1,
     )
     forecast_list = [float(x) for x in np.asarray(forecast_next)]
-    lower_bounds, upper_bounds = residual_confidence_intervals(
-        test_data, predictions, forecast_list
+    test_lower, test_upper = residual_confidence_intervals(
+        test_data, pred_list, pred_list
     )
-    ci_bounds = {"lower": lower_bounds, "upper": upper_bounds}
+    forecast_lower, forecast_upper = residual_confidence_intervals(
+        test_data, pred_list, forecast_list
+    )
+    ci_bounds = {
+        "test": {"lower": test_lower, "upper": test_upper},
+        "forecast": {"lower": forecast_lower, "upper": forecast_upper},
+    }
 
     metrics = {
         "Modelo": "Holt-Winters",


### PR DESCRIPTION
## Summary
- genera intervalos de confianza separados para las predicciones del conjunto de prueba y para los pronósticos futuros en todos los modelos
- ajusta la vista de la gráfica para consumir los intervalos del conjunto de prueba y documenta la nueva estructura de datos devuelta

## Testing
- python -m compileall my_forecast_app_v1

------
https://chatgpt.com/codex/tasks/task_e_68d432fa202c832f9b263ee4606ed761