### PR TITLE
Fix best model selection for template

### DIFF
--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -59,6 +59,10 @@ def index():
         })
         metrics_df["Rank"] = ranking.mean(axis=1).rank(method="dense").astype(int)
         best_idx = metrics_df["Rank"].idxmin()
+        if "Modelo" in metrics_df.columns:
+            best_model_name = metrics_df.loc[best_idx, "Modelo"]
+        else:
+            best_model_name = best_idx
 
         format_dict = {
             "MAE": "{:.4f}",
@@ -198,7 +202,7 @@ def index():
             selected_test_percent="",
             display_period=display_period,
             display_test_percent=test_percent,
-            best_model_name=best_idx,
+            best_model_name=best_model_name,
         )
     else:
         # Método GET: mostramos el formulario con valores por defecto


### PR DESCRIPTION
## Summary
- ensure the best model passed to the template uses the model name from the metrics table when available
- keep the previous fallback when no model name column is present

## Testing
- python -m compileall my_forecast_app_v1

------
https://chatgpt.com/codex/tasks/task_e_68d43da9e00c832fb8e49b5f9c48b2b6