### PR TITLE
Fix confidence interval shading in plot

### DIFF
--- a/my_forecast_app_v1/templates/plot.html
+++ b/my_forecast_app_v1/templates/plot.html
@@ -93,7 +93,7 @@
                     pointRadius: 0,
                     borderDash: [6, 4],
                     borderWidth: 1,
-                    fill: { target: '-1', above: ciFillColor, below: ciFillColor },
+                    fill: '-1',
                     spanGaps: true,
                     order: 0
                 }


### PR DESCRIPTION
## Summary
- adjust the Chart.js dataset configuration for the lower confidence band to use the simplified fill syntax
- ensure the background color between upper and lower confidence interval lines is rendered

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d445044f30832fa99625907b0ff0f3