### PR TITLE
Fix confidence interval shading

### DIFF
--- a/my_forecast_app_v1/templates/plot.html
+++ b/my_forecast_app_v1/templates/plot.html
@@ -71,31 +71,32 @@
 
         if (hasCI) {
             const ciLineColor = 'rgba(220, 53, 69, 0.55)';
-            const ciFillColor = 'rgba(220, 53, 69, 0.15)';
+            const ciFillColor = 'rgba(220, 53, 69, 0.18)';
             datasets.push(
                 {
                     label: 'IC Superior',
                     data: ciUpper,
                     borderColor: ciLineColor,
-                    backgroundColor: ciFillColor,
                     pointRadius: 0,
                     borderDash: [6, 4],
-                    fill: false,
                     borderWidth: 1,
                     spanGaps: true,
-                    order: 0
+                    order: -1
                 },
                 {
                     label: 'IC Inferior',
                     data: ciLower,
                     borderColor: ciLineColor,
-                    backgroundColor: ciFillColor,
                     pointRadius: 0,
                     borderDash: [6, 4],
                     borderWidth: 1,
-                    fill: '-1',
                     spanGaps: true,
-                    order: 0
+                    order: -1,
+                    fill: {
+                        target: '-1',
+                        above: ciFillColor,
+                        below: 'rgba(220, 53, 69, 0.05)'
+                    }
                 }
             );
         }
@@ -113,6 +114,9 @@
                     intersect: false
                 },
                 plugins: {
+                    filler: {
+                        propagate: false
+                    },
                     legend: {
                         labels: {
                             usePointStyle: true


### PR DESCRIPTION
## Summary
- update confidence interval datasets to render the shaded area correctly in Chart.js
- ensure the filler plugin keeps the interval shading behind the other lines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d44814224c832fa3b7e3bd1e3f34b7