### PR TITLE
Match metrics results table styling to DM table

### DIFF
--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -61,12 +61,29 @@
                     </div>
                 {% endif %}
 
-                {% if metrics_table %}
+                {% if metrics_rows %}
                     <!-- Tabla con métricas de evaluación de cada modelo -->
                     <h2>Resultados de métricas</h2>
                     <div class="table-responsive">
-                        <!-- Muestra el DataFrame de métricas -->
-                        {{ metrics_table|safe }}
+                        <table class="table table-striped table-hover table-sm text-center">
+                            <thead>
+                                <tr>
+                                    {% for column in metrics_columns %}
+                                        <th>{{ column }}</th>
+                                    {% endfor %}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for row in metrics_rows %}
+                                    <tr{% if row["is_best"] %} class="table-warning"{% endif %}>
+                                        {% for column in metrics_columns %}
+                                            <td>{{ row["values"][column] }}</td>
+                                        {% endfor %}
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                        <p><small>Se resalta la fila con el mejor desempeño.</small></p>
                     </div>
                 {% endif %}
 
@@ -83,7 +100,7 @@
             </div>
 
             <div class="tab-pane fade" id="chart" role="tabpanel" aria-labelledby="chart-tab">
-                {% if metrics_table %}
+                {% if metrics_rows %}
                     {% set initial_model = best_model_name if best_model_name else (predictions_dict|first) %}
                     <div class="row g-4">
                         <div class="col-lg-4">


### PR DESCRIPTION
## Summary
- prepare metric results in the view so the template can render them with the same Bootstrap styling used by the Diebold-Mariano table
- update the metrics section to build the table markup directly in the template and highlight the best performing model
- gate the chart tab content on the presence of metrics data to keep behaviour consistent

## Testing
- python -m compileall my_forecast_app_v1

------
https://chatgpt.com/codex/tasks/task_e_68d464967fac832fb7292f60baddd287